### PR TITLE
Propose "such as" instead of "like"

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@ which compile to the FHIR artifacts you need.</p>
     <i class="fab fa-github"></i>
   </div>
   <h4 class="h3">Source control ready</h4>
-  <p class="mb-0"><p>Unlike other tools for profiling FHIR, FSH works seamlessly with source control tools like
+  <p class="mb-0"><p>Unlike other tools for profiling FHIR, FSH works seamlessly with source control tools such as 
 GitHub. Maintain a history of changes, track contributions, and maintain agility by using FSH with source control.</p>
 </p>
 </div>


### PR DESCRIPTION
I think the intention is to show an example, not a similarity. Could also say "such as git"